### PR TITLE
Added fix to set the timelimit enddate correctly

### DIFF
--- a/create.ps1
+++ b/create.ps1
@@ -407,7 +407,7 @@ function Update-IloqAccessKeyTimeLimitSlot {
     try {
         Write-Verbose "Get KeyTimeLimitSlots of Key $($Key.Description)"
         $splatParams = @{
-            Uri     = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)//TimeLimitTitles?mode=0"
+            Uri     = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/TimeLimitTitles?mode=0"
             Method  = 'GET'
             Headers = $Headers
         }
@@ -417,58 +417,58 @@ function Update-IloqAccessKeyTimeLimitSlot {
         if ($null -ne $endDateObject ) {
             $currentEndDate = $endDateObject.LimitDateLg
         }
-        $newEndDate = Confirm-UpdateRequiredEndDateKey -NewEndDate $EndDate -CurrentEndDate $currentEndDate
-        if (-not [string]::IsNullOrWhiteSpace($newEndDate)) {
+        if (Confirm-UpdateRequiredExpireDate -NewEndDate $EndDate -CurrentEndDate $currentEndDate) {
             Write-Verbose "EndDate Update required of AccessKey [$($Key.Description)]"
-            if ($dryRun -eq $true) {
-                Write-Warning "[DryRun] Update EndDate AccessKey: [$($Key.Description)] will be executed during enforcement"
-                Write-Verbose "Current EndDate [$($Key.ExpireDate)] New EndDate: [$($newEndDate)]"
+            Write-Verbose "Update TimeLimit of AccessKey: [$($Key.Description)]. New EndDate is [$($EndDate)]"
+
+            # Retrieve the existing security accesses, Because updating Time Limits overwrites the existing accesses.
+            $splatParams = @{
+                Uri     = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/SecurityAccesses?mode=0"
+                Method  = 'GET'
+                Headers = $Headers
             }
-            Write-Verbose "Update TimeLimit of AccessKey: [$($Key.Description)]. New EndDate is [$($newEndDate)]"
+            $currentSecurityAccesses = ([array](Invoke-RestMethod @splatParams -Verbose:$false).SecurityAccesses)
+
             $body = @{
-                TimeLimitSlot = @{
-                    LimitDateLg   = $newEndDate
+                KeyScheduler                       = @{}
+                OfflineExpirationSeconds           = 0
+                OutsideUserZoneTimeLimitTitleSlots = @()
+                SecurityAccessIds                  = @()
+                TimeLimitSlots                     = @()
+            }
+            if ( $null -ne $currentSecurityAccesses.SecurityAccess_ID  ) {
+                $body.SecurityAccessIds += $currentSecurityAccesses.SecurityAccess_ID
+            }
+
+            if (-not ([string]::IsNullOrEmpty($EndDate))) {
+                $body.TimeLimitSlots += @{
+                    LimitDateLg   = $EndDate
                     SlotNo        = 1
                     TimeLimitData = @()
                 }
             }
+            if ($dryRun -eq $true) {
+                Write-Warning "[DryRun] Update EndDate AccessKey: [$($Key.Description)] will be executed during enforcement"
+                Write-Verbose "Current EndDate [$($Key.ExpireDate)] New EndDate: [$($EndDate)]"
+            }
             if (-not($dryRun -eq $true)) {
                 $splatParams = @{
-                    Uri         = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/TimeLimitTitles"
-                    Method      = 'POST'
+                    Uri         = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/SecurityAccesses"
+                    Method      = 'PUT'
                     Headers     = $Headers
-                    Body        = ($body | ConvertTo-Json)
+                    Body        = ($body | ConvertTo-Json -Depth 10)
                     ContentType = 'application/json; charset=utf-8'
                 }
                 $null = Invoke-RestMethod @splatParams -Verbose:$false
                 $AuditLogs.Add([PSCustomObject]@{
-                    Action  = 'UpdateAccount'
-                    Message = "Update end date AccessKey: [$($key.Description)] was successful"
-                    IsError = $false
-                })
+                        Action  = 'UpdateAccount'
+                        Message = "Update end date AccessKey: [$($key.Description)] was successful"
+                        IsError = $false
+                    })
             }
         }
     } catch {
         $PSCmdlet.ThrowTerminatingError($_)
-    }
-}
-
-function Confirm-UpdateRequiredEndDateKey {
-    [CmdletBinding()]
-    param(
-        [Parameter()]
-        $NewEndDate,
-
-        [Parameter()]
-        $CurrentEndDate
-    )
-    if ($NewEndDate -eq $CurrentEndDate -or ($CurrentEndDate -eq '9999-01-01T00:00:00' -and [string]::IsNullOrEmpty($NewEndDate))) {
-        Write-Verbose 'No EndDate Update update required'
-    } else {
-        if ([string]::IsNullOrEmpty($NewEndDate)) {
-            $NewEndDate = '9999-01-01T00:00:00'
-        }
-        Write-Output $NewEndDate
     }
 }
 

--- a/grant.ps1
+++ b/grant.ps1
@@ -265,7 +265,7 @@ function Update-IloqAccessKeyTimeLimitSlot {
     try {
         Write-Verbose "Get KeyTimeLimitSlots of Key $($Key.Description)"
         $splatParams = @{
-            Uri     = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)//TimeLimitTitles?mode=0"
+            Uri     = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/TimeLimitTitles?mode=0"
             Method  = 'GET'
             Headers = $Headers
         }
@@ -275,27 +275,46 @@ function Update-IloqAccessKeyTimeLimitSlot {
         if ($null -ne $endDateObject ) {
             $currentEndDate = $endDateObject.LimitDateLg
         }
-        $newEndDate = Confirm-UpdateRequiredEndDateKey -NewEndDate $EndDate -CurrentEndDate $currentEndDate
-        if (-not [string]::IsNullOrWhiteSpace($newEndDate)) {
+        if (Confirm-UpdateRequiredExpireDate -NewEndDate $EndDate -CurrentEndDate $currentEndDate) {
             Write-Verbose "EndDate Update required of AccessKey [$($Key.Description)]"
-            if ($dryRun -eq $true) {
-                Write-Warning "[DryRun] Update EndDate AccessKey: [$($Key.Description)] will be executed during enforcement"
-                Write-Verbose "Current EndDate [$($Key.ExpireDate)] New EndDate: [$($newEndDate)]"
+            Write-Verbose "Update TimeLimit of AccessKey: [$($Key.Description)]. New EndDate is [$($EndDate)]"
+
+            # Retrieve the existing security accesses, Because updating Time Limits overwrites the existing accesses.
+            $splatParams = @{
+                Uri     = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/SecurityAccesses?mode=0"
+                Method  = 'GET'
+                Headers = $Headers
             }
-            Write-Verbose "Update TimeLimit of AccessKey: [$($Key.Description)]. New EndDate is [$($newEndDate)]"
+            $currentSecurityAccesses = ([array](Invoke-RestMethod @splatParams -Verbose:$false).SecurityAccesses)
+
             $body = @{
-                TimeLimitSlot = @{
-                    LimitDateLg   = $newEndDate
+                KeyScheduler                       = @{}
+                OfflineExpirationSeconds           = 0
+                OutsideUserZoneTimeLimitTitleSlots = @()
+                SecurityAccessIds                  = @()
+                TimeLimitSlots                     = @()
+            }
+            if ( $null -ne $currentSecurityAccesses.SecurityAccess_ID  ) {
+                $body.SecurityAccessIds += $currentSecurityAccesses.SecurityAccess_ID
+            }
+
+            if (-not ([string]::IsNullOrEmpty($EndDate))) {
+                $body.TimeLimitSlots += @{
+                    LimitDateLg   = $EndDate
                     SlotNo        = 1
                     TimeLimitData = @()
                 }
             }
+            if ($dryRun -eq $true) {
+                Write-Warning "[DryRun] Update EndDate AccessKey: [$($Key.Description)] will be executed during enforcement"
+                Write-Verbose "Current EndDate [$($Key.ExpireDate)] New EndDate: [$($EndDate)]"
+            }
             if (-not($dryRun -eq $true)) {
                 $splatParams = @{
-                    Uri         = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/TimeLimitTitles"
-                    Method      = 'POST'
+                    Uri         = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/SecurityAccesses"
+                    Method      = 'PUT'
                     Headers     = $Headers
-                    Body        = ($body | ConvertTo-Json)
+                    Body        = ($body | ConvertTo-Json -Depth 10)
                     ContentType = 'application/json; charset=utf-8'
                 }
                 $null = Invoke-RestMethod @splatParams -Verbose:$false
@@ -308,25 +327,6 @@ function Update-IloqAccessKeyTimeLimitSlot {
         }
     } catch {
         $PSCmdlet.ThrowTerminatingError($_)
-    }
-}
-
-function Confirm-UpdateRequiredEndDateKey {
-    [CmdletBinding()]
-    param(
-        [Parameter()]
-        $NewEndDate,
-
-        [Parameter()]
-        $CurrentEndDate
-    )
-    if ($NewEndDate -eq $CurrentEndDate -or ($CurrentEndDate -eq '9999-01-01T00:00:00' -and [string]::IsNullOrEmpty($NewEndDate))) {
-        Write-Verbose 'No EndDate Update update required'
-    } else {
-        if ([string]::IsNullOrEmpty($NewEndDate)) {
-            $NewEndDate = '9999-01-01T00:00:00'
-        }
-        Write-Output $NewEndDate
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ You can change this behavior in the configuration by selecting the IsUpdatePerso
 - The Enddate of the AccessKey is kept in sync with the person's primary contract enddate to ensure that it is always up-to-date. An additional check is run in some sort of extra process in the following HelloId Actions: **Create, Update, Grant, and Revoke**. This check verifies if the accessKey enddate differs from the enddate of the primary contract, and if so, it updates the enddate on the access key. This is done on all the access keys assigned to the person. Because this process is slightly different from the normal Account LifeCycle or managing permissions, it does not throw termination errors but instead adds a warning to the process logging. (Of course, this can be changed.)
 - Please note that after updating the security access on the key with HelloID, the security accesses are granted in the system but are not directly synced to the actual key. This programming happens either by passing through an online reader (for example, an active door reader capable of syncing the latest changes) or by programming with a physical programming key.
 - There are two types of end dates that can be updated on an AccessKey. There is an ExpireDate and a Timelimit Slot. The ExpireDate is only an informational value, while the Timelimit slot actually prevents access whenever the end date is expired. The connector keeps both dates in sync with the primary contract end date, as already mentioned above.
-- The end date in the Time Limit cannot be cleared, so if it needs to be cleared, the end date will be set to 9999-01-01 instead.
+
 
 
 #### Permissions Remarks
@@ -97,6 +97,7 @@ The connector process for managing access keys involves the creation of user acc
  - The grant or revoke permissions process is created to set the specified permissions for all access keys assigned to a user.
  - When a person has multiple keys assigned, the granted permissions for each key are displayed as sub-permissions in the entitlement overview.
  - After each change in Security Access permissions, the key needs to be ordered in order to make the new permission set available for ordering [More info Here](https://s5.iloq.com/iLOQPublicApiDoc/use_cases/iLOQ_ManageKeysSecurityAccessesRemotely.html). This can cause inconvenience whenever a permission is revoked and the CanOrder action fails. The webservice has already deleted the permission, so in the retry, the permission is already removed according to the API. This means that the key should always be ordered in the revoke action, even if the API indicates that the permission has already been removed.
+ - The connector does support only locking systems that have zone functionality On
 
 ## Getting help
 

--- a/update.ps1
+++ b/update.ps1
@@ -382,7 +382,7 @@ function Update-IloqAccessKeyTimeLimitSlot {
     try {
         Write-Verbose "Get KeyTimeLimitSlots of Key $($Key.Description)"
         $splatParams = @{
-            Uri     = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)//TimeLimitTitles?mode=0"
+            Uri     = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/TimeLimitTitles?mode=0"
             Method  = 'GET'
             Headers = $Headers
         }
@@ -392,58 +392,58 @@ function Update-IloqAccessKeyTimeLimitSlot {
         if ($null -ne $endDateObject ) {
             $currentEndDate = $endDateObject.LimitDateLg
         }
-        $newEndDate = Confirm-UpdateRequiredEndDateKey -NewEndDate $EndDate -CurrentEndDate $currentEndDate
-        if (-not [string]::IsNullOrWhiteSpace($newEndDate)) {
+        if (Confirm-UpdateRequiredExpireDate -NewEndDate $EndDate -CurrentEndDate $currentEndDate) {
             Write-Verbose "EndDate Update required of AccessKey [$($Key.Description)]"
-            if ($dryRun -eq $true) {
-                Write-Warning "[DryRun] Update EndDate AccessKey: [$($Key.Description)] will be executed during enforcement"
-                Write-Verbose "Current EndDate [$($Key.ExpireDate)] New EndDate: [$($newEndDate)]"
+            Write-Verbose "Update TimeLimit of AccessKey: [$($Key.Description)]. New EndDate is [$($EndDate)]"
+
+            # Retrieve the existing security accesses, Because updating Time Limits overwrites the existing accesses.
+            $splatParams = @{
+                Uri     = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/SecurityAccesses?mode=0"
+                Method  = 'GET'
+                Headers = $Headers
             }
-            Write-Verbose "Update TimeLimit of AccessKey: [$($Key.Description)]. New EndDate is [$($newEndDate)]"
+            $currentSecurityAccesses = ([array](Invoke-RestMethod @splatParams -Verbose:$false).SecurityAccesses)
+
             $body = @{
-                TimeLimitSlot = @{
-                    LimitDateLg   = $newEndDate
+                KeyScheduler                       = @{}
+                OfflineExpirationSeconds           = 0
+                OutsideUserZoneTimeLimitTitleSlots = @()
+                SecurityAccessIds                  = @()
+                TimeLimitSlots                     = @()
+            }
+            if ( $null -ne $currentSecurityAccesses.SecurityAccess_ID  ) {
+                $body.SecurityAccessIds += $currentSecurityAccesses.SecurityAccess_ID
+            }
+
+            if (-not ([string]::IsNullOrEmpty($EndDate))) {
+                $body.TimeLimitSlots += @{
+                    LimitDateLg   = $EndDate
                     SlotNo        = 1
                     TimeLimitData = @()
                 }
             }
+            if ($dryRun -eq $true) {
+                Write-Warning "[DryRun] Update EndDate AccessKey: [$($Key.Description)] will be executed during enforcement"
+                Write-Verbose "Current EndDate [$($Key.ExpireDate)] New EndDate: [$($EndDate)]"
+            }
             if (-not($dryRun -eq $true)) {
                 $splatParams = @{
-                    Uri         = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/TimeLimitTitles"
-                    Method      = 'POST'
+                    Uri         = "$($config.BaseUrl)/api/v2/Keys/$($Key.FNKey_ID)/SecurityAccesses"
+                    Method      = 'PUT'
                     Headers     = $Headers
-                    Body        = ($body | ConvertTo-Json)
+                    Body        = ($body | ConvertTo-Json -Depth 10)
                     ContentType = 'application/json; charset=utf-8'
                 }
                 $null = Invoke-RestMethod @splatParams -Verbose:$false
                 $AuditLogs.Add([PSCustomObject]@{
-                    Action  = 'UpdateAccount'
-                    Message = "Update end date AccessKey: [$($key.Description)] was successful"
-                    IsError = $false
-                })
+                        Action  = 'UpdateAccount'
+                        Message = "Update end date AccessKey: [$($key.Description)] was successful"
+                        IsError = $false
+                    })
             }
         }
     } catch {
         $PSCmdlet.ThrowTerminatingError($_)
-    }
-}
-
-function Confirm-UpdateRequiredEndDateKey {
-    [CmdletBinding()]
-    param(
-        [Parameter()]
-        $NewEndDate,
-
-        [Parameter()]
-        $CurrentEndDate
-    )
-    if ($NewEndDate -eq $CurrentEndDate -or ($CurrentEndDate -eq '9999-01-01T00:00:00' -and [string]::IsNullOrEmpty($NewEndDate))) {
-        Write-Verbose 'No EndDate Update update required'
-    } else {
-        if ([string]::IsNullOrEmpty($NewEndDate)) {
-            $NewEndDate = '9999-01-01T00:00:00'
-        }
-        Write-Output $NewEndDate
     }
 }
 


### PR DESCRIPTION
- Changed how the timelimit slot is updated from the specific endpoint {{ILoqUrl}}/api/v2/Keys/{KeyID}/TimeLimitTitles/ To a put call to {{ILoqUrl}}/api/v2/Keys/{{KeyID}}/SecurityAccesses (As suggested by iLOQ)
- 
- Updated end date update from 9999-01-01 to remove the slot